### PR TITLE
03 Replace temp with query

### DIFF
--- a/src/statement.js
+++ b/src/statement.js
@@ -9,7 +9,7 @@ function statement(invoice, plays) {
   }).format;
 
   for (let perf of invoice.performances) {
-    const play = plays[perf.playID];
+    const play = playFor(perf);
 
     let thisAmount = amountFor(perf, play);
 
@@ -26,6 +26,10 @@ function statement(invoice, plays) {
   result += `Amount owed is ${format(totalAmount / 100)}\n`;
   result += `You earned ${volumeCredits} credits\n`;
   return result;
+
+  function playFor(aPerformance) {
+    return plays[aPerformance.playID];
+  }
 
   function amountFor(aPerformance, play) {
     let result = 0;

--- a/src/statement.js
+++ b/src/statement.js
@@ -9,7 +9,9 @@ function statement(invoice, plays) {
   }).format;
 
   for (let perf of invoice.performances) {
-    let thisAmount = amountFor(perf, playFor(perf));
+    const play = playFor(perf);
+
+    let thisAmount = amountFor(perf, play);
 
     // add volume credits
     volumeCredits += Math.max(perf.audience - 30, 0);

--- a/src/statement.js
+++ b/src/statement.js
@@ -9,16 +9,15 @@ function statement(invoice, plays) {
   }).format;
 
   for (let perf of invoice.performances) {
-    const play = playFor(perf);
-
-    let thisAmount = amountFor(perf, play);
+    let thisAmount = amountFor(perf, playFor(perf));
 
     // add volume credits
     volumeCredits += Math.max(perf.audience - 30, 0);
     // add extra credit for every ten comedy attendees
-    if ("comedy" === play.type) volumeCredits += Math.floor(perf.audience / 5);
+    if ("comedy" === playFor(perf).type)
+      volumeCredits += Math.floor(perf.audience / 5);
     // print line for this order
-    result += ` ${play.name}: ${format(thisAmount / 100)} (${
+    result += ` ${playFor(perf).name}: ${format(thisAmount / 100)} (${
       perf.audience
     } seats)\n`;
     totalAmount += thisAmount;


### PR DESCRIPTION
## Replace Temp with Query (178)

### Changes
- **replace `play` temporary variable by `playFor` query**
    - When I’m breaking down a long function, I like to get rid of variables like `play`, because temporary variables create a lot of locally scoped names that complicate extractions.
    - The great benefit of removing local variables is that it makes it much easier to do extractions, since there is less local scope to deal with. Indeed, usually I’ll take out local variables before I do any extractions.

### Techniques

#### Replace Temp with Query [[definition](https://github.com/arnau-rius/theatrical-players-refactoring/blob/master/docs/techniques.md#replace-temp-with-query-178) and [refactoring.org](https://refactoring.com/catalog/replaceTempWithQuery.html)]
- Use when you want to provide even more self-explaining code for a variable that is instantiated with a complex expression.
- This is also useful when breaking up a large function. 
- 🐍 In python classes, the equivalent is basically turning
temporary variables into @property methods or computed fields.
